### PR TITLE
Cleanups after repo split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Python bytecode files
+*.py[co]
+
+# Vim backup files
+*~

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ If you cannot use conda for some reason, see "Getting the Python Dependencies
 Without Conda".
 
 In any case, you will require openMHA, or MHA if you happen to have a
-commercial license.
+commercial license.  See also its [corresponding
+example](https://github.com/HoerTech-gGmbH/openMHA/tree/master/examples/09-localizer-steering-beamformer)
+for how to set it up appropriately.
 
 ### The Easy Way
 
@@ -75,7 +77,10 @@ description of the Python servers.
 
 ### Launching the Visualisation
 
-To start the visualisation using the default options, simply run
+To start the visualisation using the default options, which are optimized for
+the corresponding openMHA
+[example](https://github.com/HoerTech-gGmbH/openMHA/tree/master/examples/09-localizer-steering-beamformer),
+simply run
 
     python mha_server.py
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Acoustic Echo and Noise Control (IWAENC 2014), pp. 100 -- 104, Antibes, France,
 ## Installation
 
 The preferred way of installing this project is, naturally, "The Easy Way".
-If you cannot use conda for some reason, see "Getting the Python Dependencies 
+If you cannot use conda for some reason, see "Getting the Python Dependencies
 Without Conda".
 
 In any case, you will require openMHA, or MHA if you happen to have a

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ relatively brief.
 
 As mentioned above, the web-apps are served over HTTP, so they are accessed via
 URLs.  Since these URLs can be somewhat complex due to the query strings used
-to parameterise the web-apps, the HTTP server knows shortcuts for each plot
+to parameterize the web-apps, the HTTP server knows shortcuts for each plot
 type: "2d", "pseudo3d", "polar", and "tiled".  They can be used in a URL like
 so:
 
@@ -186,7 +186,7 @@ The other plot types show up as clickable URLs, so it is easy to switch to a
 different type of visualisation, or to open several in different browser
 windows and/or tabs.  Note, however, that the Python servers and the web-apps
 are not designed for this, so it might be too slow to be usable (except for
-tabs, where it appears that modern browsers optimise away inactive tabs).
+tabs, where it appears that modern browsers optimize away inactive tabs).
 
 #### Common controls
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ HTTP is for serving the web applications, and the WebSocket is for sending data
 and commands.
 
 The TCP server is identical to the MHA server, only that it receives data from
-a TCP client instead of requesting it from an MHA instance.  It was written for
-visualising data from different programming languages — primarily MATLAB, but
-any language that supports TCP/IP will work, e.g., Python.
+a TCP client instead of requesting it from an MHA instance.  It was written as
+a debugging tool for visualising data from different programming languages —
+primarily MATLAB, but any language that supports TCP/IP will work, e.g.,
+Python.
 
 Two support files are provided: `connect_to_webapp.m` for MATLAB and Octave,
 and `connect_to_webapp.py` for Python.  Both work basically the same way: they

--- a/README.md
+++ b/README.md
@@ -2,20 +2,17 @@
 
 ## Introduction
 
-This project is at its core an implementation of a localisation algorithm based
-on GCC-PHAT (see [0] and [1]).  This is done as a triplet of plug-ins for openMHA.
+This repository contains a tool for visualizing a localisation algorithm based
+on GCC-PHAT (see [0] and [1]).  It utilizes a triplet of plug-ins written for
+[openMHA](http://www.openmha.org/):
 
 - feature extraction, i.e., the actual GCC-PHAT computation,
 - classification (linear SVM followed by a sigmoid transform), and
 - pooling (i.e., grouping values over a specified duration, by sum, maximum, or
   mean).
 
-Furthermore, this project contains an assortment of (vaguely) related software,
-namely:
-
-- a Python class for communicating with an openMHA instance
-- an HTML5 based visualisation of the localisation
-
+Furthermore, this project contains a Python class for communicating with an
+openMHA instance.
 
 [0] C. Knapp and G. C. Carter, “The generalized correlation method for
 estimation of time delay,” IEEE Transactions on Acoustics, Speech and Signal
@@ -26,22 +23,16 @@ probabilistic acoustic source localization,” In: International Workshop on
 Acoustic Echo and Noise Control (IWAENC 2014), pp. 100 -- 104, Antibes, France,
 2014
 
-## Project Structure
-
-The project is roughly structured as follows:
-
-- The Python class and the HTML5 based visualisation are both in the directory
-  `visualisation_web/`.
-
 ## Installation
 
 The preferred way of installing this project is, naturally, "The Easy Way".
 If you cannot use conda for some reason, see "Getting the Python Dependencies 
 Without Conda".
 
-### The Easy Way
+In any case, you will require openMHA, or MHA if you happen to have a
+commercial license.
 
-You will, of course, require an openMHA installation.
+### The Easy Way
 
 The next step is installing the dependencies of the visualisation itself.  The
 recommended way is to use [conda](http://conda.pydata.org/docs/).  For this
@@ -51,9 +42,8 @@ By executing the commands
     conda env create
     conda activate doasvm_demo
 
-in the directory where this README_visualization.md file is located.
-A conda environment that is identical to the one used to develop and
-test this project will be created and activated.
+in this project's top-level directory.  A conda environment that is identical
+to the one used to develop and test this project will be created and activated.
 
 If you wish to send data to the TCP server (see "Structure of the
 Visualisation" below) from within MATLAB, you will additionally require the
@@ -87,16 +77,16 @@ description of the Python servers.
 
 To start the visualisation using the default options, simply run
 
-    python visualisation_web/mha_server.py
+    python mha_server.py
 
 Or, if you wish to feed your own data into the visualisation, run
 
-    python visualisation_web/tcp_server.py
+    python tcp_server.py
 
 This will start the server and open the visualisation in a web browser.  See
-the output of `python visualisation_web/mha_server.py --help` or `python
-visualisation_web/tcp_server.py --help` for a list of options (e.g., the MHA's
-host and port), and read on for a more thorough description.
+the output of `python mha_server.py --help` or `python tcp_server.py --help`
+for a list of options (e.g., the MHA's host and port), and read on for a more
+thorough description.
 
 ### Structure of the Visualisation
 
@@ -116,12 +106,11 @@ over HTTP (thus enabling remote viewing), and it acts as a *bridge* between the
 web application and an MHA instance.  For the latter, it receives commands from
 the web app over the aforementioned WebSocket, and communicates with an MHA
 instance over TCP via MHA's simple network protocol (see the file
-`visualisation_web/MHAConnection.py` for the details).  Note that the TCP
-connection is made on-demand, in order to accommodate other MHA clients, since
-the MHA only supports a single TCP connection.  However, this does not appear
-to add an appreciable amount of overhead.  Both the HTTP and WebSocket
-components are implemented with the [Tornado](http://www.tornadoweb.org/)
-Python library.
+`MHAConnection.py` for the details).  Note that the TCP connection is made
+on-demand, in order to accommodate other MHA clients, since the MHA only
+supports a single TCP connection.  However, this does not appear to add an
+appreciable amount of overhead.  Both the HTTP and WebSocket components are
+implemented with the [Tornado](http://www.tornadoweb.org/) Python library.
 
 In summary, the basic network structure looks like this:
 
@@ -139,15 +128,14 @@ a TCP client instead of requesting it from an MHA instance.  It was written for
 visualising data from different programming languages — primarily MATLAB, but
 any language that supports TCP/IP will work, e.g., Python.
 
-Two support files are provided: `visualisation_web/connect_to_webapp.m` for
-MATLAB and Octave, and `visualisation_web/connect_to_webapp.py` for Python.
-Both work basically the same way: they return a function (in MATLAB/Octave a
-function *handle*) with which you can send data to the TCP server, along with
-the object that encapsulates the TCP connection.  Additionally, the test file
-`./tools/test_tcp_server.m` is provided for MATLAB/Octave, which sends test
-data to the TCP server. See the documentation in the aforementioned files for
-more information (e.g., `help test_tcp_server`,
-`pydoc visualisation_web/connect_to_webapp.py`).
+Two support files are provided: `connect_to_webapp.m` for MATLAB and Octave,
+and `connect_to_webapp.py` for Python.  Both work basically the same way: they
+return a function (in MATLAB/Octave a function *handle*) with which you can
+send data to the TCP server, along with the object that encapsulates the TCP
+connection.  Additionally, the test file `./tools/test_tcp_server.m` is
+provided for MATLAB/Octave, which sends test data to the TCP server. See the
+documentation in the aforementioned files for more information (e.g., `help
+test_tcp_server`, `pydoc connect_to_webapp.py`).
 
 ### The Visualisation Web Applications
 
@@ -363,11 +351,11 @@ the different controls.
 
 You can change the look of the visualisation (line colors, line thickness, font
 size, etc.) by creating a file with the name
-`visualisation_web/visualisation/css/site_custom.css`.  This file is loaded
-after all other CSS files, thus it will override all default styles, with the
-exception of styles that are dynamically computed via JavaScript (but it
-doesn't make sense to override those anyway).  If it does not exist, then the
-server will return a "file not found" error and nothing will happen.
+`visualisation/css/site_custom.css`.  This file is loaded after all other CSS
+files, thus it will override all default styles, with the exception of styles
+that are dynamically computed via JavaScript (but it doesn't make sense to
+override those anyway).  If it does not exist, then the server will return a
+"file not found" error and nothing will happen.
 
 #### Security Concerns
 

--- a/mha_server.py
+++ b/mha_server.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--classification-id',
-        default=b'doasvm_classification',
+        default=b'svm',
         type=lambda s: (s if type(s) == bytes else s.encode()),
         help="""The ID of a doasvm_classification instance.  This is used to
         fetch the "angles" variable in order to pass additional parameters to
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--pooling-id',
-        default=b'acPooling_wave',
+        default=b'pool',
         type=lambda s: (s if type(s) == bytes else s.encode()),
         help="""The ID of the desired acPooling_wave instance.  This is the
         instance that will be controlled from the web app.
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--pool-path',
-        default=b'',
+        default=b'mha.doachain.doasvm_mon.pool',
         type=lambda s: (s if type(s) == bytes else s.encode()),
         help="""The full path to the desired "pool" variable to visualise.  If
         unset, it is assumed that a doasvm_mon instance (named "doasvm_mon")


### PR DESCRIPTION
This small series of commits simply adapts the `README.md` file (with some minor cleanup) to the changes that resulted from this repo being split off from its previous parent project. I also changed the defaults in `mha_server.py` to match the corresponding example in openMHA.  Finally, I also added a `.gitignore` file, but that's boring.

If you want to test these changes, start the openMHA example, then follow the instructions in `README.md`.  The visualization should just start and run properly.