### PR TITLE
Drop Python 2 compatibility

### DIFF
--- a/MHAConnection.py
+++ b/MHAConnection.py
@@ -22,8 +22,8 @@ class MHAConnection(telnetlib.Telnet):
         """
 
         self.write(buffer)
-        err_code, _match, resp = self.expect([b'\(MHA:success\)',
-                                              b'\(MHA:failure\)'])
+        err_code, _match, resp = self.expect([br'\(MHA:success\)',
+                                              br'\(MHA:failure\)'])
         if err_code == 0:
             return resp.rpartition(b'(MHA:success)')[0].strip()
         else:

--- a/MHAConnection.py
+++ b/MHAConnection.py
@@ -27,8 +27,10 @@ class MHAConnection(telnetlib.Telnet):
         if err_code == 0:
             return resp.rpartition(b'(MHA:success)')[0].strip()
         else:
-            raise ValueError('Error sending message "{}" with error code {}:\nResponse: {}'
-                             .format(buffer, err_code, resp))
+            raise ValueError(
+                'Error sending message "{}" with error code {}:\nResponse: {}'
+                .format(buffer, err_code, resp)
+            )
 
     def get_val(self, path):
         """Get the value of the variable located at "path".

--- a/MHAConnection.py
+++ b/MHAConnection.py
@@ -1,15 +1,9 @@
 from ast import literal_eval
 from collections import Sequence, MutableSequence
 from encodings.utf_8 import encode as encode_utf8
-import sys
 import telnetlib
 
-if sys.version_info.major == 2:
-    from string import maketrans
-else:
-    maketrans = str.maketrans
-
-round_to_square_brackets = maketrans('()', '[]')
+round_to_square_brackets = str.maketrans('()', '[]')
 
 
 class MHAConnection(telnetlib.Telnet):

--- a/README.md
+++ b/README.md
@@ -65,10 +65,8 @@ performance and should thus be given preference.
 If you cannot use conda, or do not want to, then you must install the following
 packages (e.g., with `pip` or the system package manager):
 
-- [Python](http://www.python.org) (version 2.7 or 3.x, tested with 2.7 and
-  3.3), and
-- [Tornado](http://www.tornadoweb.org) (tested with 4.0.1; earlier versions
-  tested with 3.1.1).
+- [Python](http://www.python.org) (version 3.x, tested with 3.7), and
+- [Tornado](http://www.tornadoweb.org) (tested with 6.0.3).
 
 ## Users Guide
 

--- a/connect_to_webapp.py
+++ b/connect_to_webapp.py
@@ -1,11 +1,5 @@
 from collections import Sequence
 import socket
-import sys
-
-# Python 3 has no unicode type, but we need to test for it in Python 2, so
-# create an alias.
-if sys.version_info.major != 2:
-    unicode = str
 
 
 def connect_to_webapp(host="localhost", port=9990):
@@ -32,8 +26,7 @@ def connect_to_webapp(host="localhost", port=9990):
 
     def send_data(data):
 
-        if not isinstance(data, Sequence) or isinstance(data, (str, bytes,
-                                                               unicode)):
+        if not isinstance(data, Sequence) or isinstance(data, (str, bytes)):
             raise ValueError('Invalid data type "{}".'.format(type(data)))
 
         data_str = str(data).strip('[]()').replace(',', '')

--- a/mha_server.py
+++ b/mha_server.py
@@ -63,9 +63,9 @@ class LoopingWebSocket(server_common.MyWebSocketHandler):
             elif 'beamformer' in message:
                 print('Beamformer = {}'.format(message['beamformer']))
                 with MHAConnection(self.mha_host, self.mha_port, self.interval) as mha_conn:
-                    if(message['beamformer'] is False):
+                    if message['beamformer'] is False:
                         mha_conn.set_val(b'mha.doachain.post.select', "NoBf")
-                    elif(message['beamformer'] is True):
+                    elif message['beamformer'] is True:
                         mha_conn.set_val(b'mha.doachain.post.select', "Bf")
                     else:
                         print('Unknown message "{}"'.format(message))

--- a/mha_server.py
+++ b/mha_server.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import json
 
 from MHAConnection import MHAConnection

--- a/mha_server.py
+++ b/mha_server.py
@@ -63,10 +63,10 @@ class LoopingWebSocket(server_common.MyWebSocketHandler):
             elif 'beamformer' in message:
                 print('Beamformer = {}'.format(message['beamformer']))
                 with MHAConnection(self.mha_host, self.mha_port, self.interval) as mha_conn:
-                    if(message['beamformer']==False):
-                        mha_conn.set_val(b'mha.doachain.post.select',"NoBf")
-                    elif(message['beamformer']==True):
-                        mha_conn.set_val(b'mha.doachain.post.select',"Bf")
+                    if(message['beamformer'] is False):
+                        mha_conn.set_val(b'mha.doachain.post.select', "NoBf")
+                    elif(message['beamformer'] is True):
+                        mha_conn.set_val(b'mha.doachain.post.select', "Bf")
                     else:
                         print('Unknown message "{}"'.format(message))
             elif 'new_interval' in message:
@@ -76,6 +76,7 @@ class LoopingWebSocket(server_common.MyWebSocketHandler):
                 print('Unknown message "{}"'.format(message))
         except Exception as e:
             print("Error handling message \"{}\": {}".format(message, e))
+
 
 if __name__ == '__main__':
 

--- a/server_common.py
+++ b/server_common.py
@@ -1,9 +1,5 @@
 import os
-
-try:
-    from urllib.parse import quote as url_quote
-except:
-    from urllib import quote as url_quote
+from urllib.parse import quote as url_quote
 
 from tornado import httpserver, ioloop, web, websocket
 

--- a/tcp_server.py
+++ b/tcp_server.py
@@ -69,6 +69,7 @@ class TCPListener(tcpserver.TCPServer):
         self._stream = stream
         self._read_line()
 
+
 if __name__ == '__main__':
 
     import argparse

--- a/tcp_server.py
+++ b/tcp_server.py
@@ -54,7 +54,7 @@ class TCPListener(tcpserver.TCPServer):
 
         # When sending data via java_tcp(), Java stores the chars in *two*
         # bytes.  One of them is usually a NULL byte, so filter those out, too.
-        data = re.sub('\s+', ', ', data.strip().decode().replace('\0', ''))
+        data = re.sub(r'\s+', ', ', data.strip().decode().replace('\0', ''))
         data = literal_eval('[' + data + ']')
         if len(data) == self._model_length:
             _p[0] = data

--- a/tcp_server.py
+++ b/tcp_server.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ast import literal_eval
 import json
 import re


### PR DESCRIPTION
This series of commits removes compatibility code for Python 2, since upstream does not support it anymore (even though enterprise Linux distributions still will), and the Conda environment has been on Python 3.x for a long time now.  Since we prefer Conda anyway, and all mainstream Linux distributions are in the midst of (working towards) removing Python 2 themselves, I see no point in maintaining backwards compatibility.  There are also a couple of clean-up commits that mainly fix up issues mentioned by `flake8`.

I have tested the visualization locally, and don't expect this to cause any problems, but would still feel better if at least one other person also tested this.